### PR TITLE
Allow module to be directly required

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shurcooL/graphql
+module github.com/cli/shurcooL-graphql
 
 go 1.13
 


### PR DESCRIPTION
Allow module to be directly required without needing a replace directive.

This directly affects cli/cli#1389.

For reference, it might be good to consider pushing this type of thing upstream, e.g., shurcooL/graphql#53.