### PR TITLE
Add fields to Error and export Error, Errors for type assertion

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -87,7 +87,7 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	}
 	var out struct {
 		Data   *json.RawMessage
-		Errors errors
+		Errors Errors
 		//Extensions interface{} // Unused.
 	}
 	err = json.NewDecoder(resp.Body).Decode(&out)
@@ -108,20 +108,23 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	return nil
 }
 
-// errors represents the "errors" array in a response from a GraphQL server.
+// Errors represents the "errors" array in a response from a GraphQL server.
 // If returned via error interface, the slice is expected to contain at least 1 element.
 //
-// Specification: https://facebook.github.io/graphql/#sec-Errors.
-type errors []struct {
+// Specification: http://spec.graphql.org/June2018/#sec-Errors
+type Errors []struct {
 	Message   string
 	Locations []struct {
 		Line   int
 		Column int
 	}
+	Path       []interface{}
+	Extensions map[string]interface{}
+	Type       string
 }
 
 // Error implements error interface.
-func (e errors) Error() string {
+func (e Errors) Error() string {
 	b := strings.Builder{}
 	l := len(e)
 	for i, err := range e {


### PR DESCRIPTION
This PR updates the error handling to firstly export `Error` and `Errors` for type assertion in `go-gh`, and secondly by capturing additional fields that the GitHub GQL API might return. As far as I could tell there is not a spec on the errors it returns but these are fields I have encountered. 

cc https://github.com/cli/go-gh/issues/97